### PR TITLE
resolve issue 1 test failure

### DIFF
--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,13 +60,13 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.34")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
         .andReturn();
   }
 

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -6,7 +6,7 @@
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
+    "status" : 200,
     "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",


### PR DESCRIPTION
### **Design:**
**1st Issue:**  Wrong ticker (was AAPL instead of FB)  in get URL for testGetLastTradedPrice() method in IexRestControllerTest.java file

**2nd Issue:** Response status was set to 404 instead of 200 as needed (mentioned in WireMock doc)

**3rd Issue:** Expected price for FB in testGetLastTradedPrice() method did not match actual price given in lastTradedPrice.json file for FB ticker (186.34 vs. 186.3011)

### **Test Evidence:**
![Issue1-Fiex](https://user-images.githubusercontent.com/35613238/176275026-005e92f3-8d6b-419f-82bb-25245cd7736a.PNG)
